### PR TITLE
fix the AdditionalLighting always be closed

### DIFF
--- a/Packages/com.deltation.toon-rp/Runtime/Lighting/ToonTiledLighting.cs
+++ b/Packages/com.deltation.toon-rp/Runtime/Lighting/ToonTiledLighting.cs
@@ -174,7 +174,9 @@ namespace DELTation.ToonRP.Lighting
         public void SetTiledLightingKeyword(CommandBuffer cmd, bool enabled)
         {
             cmd.SetKeyword(_tiledLightingKeyword, enabled);
-            _lighting.SetAdditionalLightsKeywords(cmd, ToonCameraRendererSettings.AdditionalLightsMode.Off);
+            // fix the problem that AdditionalLightsMode will allways be closed
+            if (enabled)
+                _lighting.SetAdditionalLightsKeywords(cmd, ToonCameraRendererSettings.AdditionalLightsMode.Off);
         }
 
         private static class ShaderIds


### PR DESCRIPTION
The AdditionalLighting will always be closed whether or not TiledLighting is open.